### PR TITLE
fixed API version

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -26,7 +26,7 @@ spec:
 
 ---
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: devops-toolkit


### PR DESCRIPTION
Warning: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler horizontalpodautoscaler.autoscaling/devops-toolkit created

changed to autoscaling/v2